### PR TITLE
CONTRIB-7598: fix failing unit tests in Moodle 3.5.4+

### DIFF
--- a/tests/mail_test.php
+++ b/tests/mail_test.php
@@ -283,8 +283,11 @@ class mod_hsuforum_mail_testcase extends advanced_testcase {
 
         // Reset the message sink for other tests.
         $this->helper->messagesink = $this->redirectMessages();
-        $event = reset($events);
-        $this->assertEquals($course->id, $event->other['courseid']);
+        foreach ($events as $event) {
+            if ($event instanceof core\event\notification_sent) {
+                $this->assertEquals($course->id, $event->other['courseid']);
+            }
+        }
     }
 
     public function test_forced_subscription() {


### PR DESCRIPTION
Fix for https://tracker.moodle.org/browse/CONTRIB-7598