### PR TITLE
TASK: Address PHP deprecation

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -2149,15 +2149,15 @@ function hsuforum_get_readable_forums($userid, $courseid=0, $excludeanonymous = 
  * @global object
  * @global object
  * @param array $searchterms array of search terms, e.g. word +word -word
+ * @param int &$totalcount
  * @param int $courseid if 0, we search through the whole site
  * @param int $limitfrom
  * @param int $limitnum
- * @param int &$totalcount
  * @param string $extrasql
  * @return array|bool Array of posts found or false
  */
-function hsuforum_search_posts($searchterms, $courseid=0, $limitfrom=0, $limitnum=50,
-                            &$totalcount, $extrasql='') {
+function hsuforum_search_posts($searchterms, &$totalcount, $courseid=0, $limitfrom=0, $limitnum=50,
+                            $extrasql='') {
     global $CFG, $DB, $USER;
     require_once($CFG->libdir.'/searchlib.php');
 

--- a/search.php
+++ b/search.php
@@ -161,7 +161,7 @@ $searchform = hsuforum_search_form($course, $forumid, $search);
 
 $PAGE->navbar->add($strsearch, new moodle_url('/mod/hsuforum/search.php', array('id'=>$course->id)));
 $PAGE->navbar->add($strsearchresults);
-if (!$posts = hsuforum_search_posts($searchterms, $course->id, $page*$perpage, $perpage, $totalcount)) {
+if (!$posts = hsuforum_search_posts($searchterms, $totalcount, $course->id, $page*$perpage, $perpage)) {
     $PAGE->set_title($strsearchresults);
     $PAGE->set_heading($course->fullname);
     echo $OUTPUT->header();


### PR DESCRIPTION
As of PHP 8.0, a deprecation log item is thrown when a required parameter follows an optional parameter:

```
Deprecated: Required parameter $totalcount follows optional parameter $courseid in /var/www/html/vendor/moodle/moodle/mod/hsuforum/lib.php on line 2159
```

By changing the order appropriately, this can be fixed. It is backwards-compatible to any currently supported PHP version (and even much older ones).