### PR TITLE
Move formheading/hidehtml code to just before footer

### DIFF
--- a/post.php
+++ b/post.php
@@ -569,27 +569,6 @@ if ($USER->id != $post->userid) {   // Not the original author, so add a message
     unset($data);
 }
 
-$formheading = '';
-if (!empty($parent)) {
-    $formheading = get_string("yourreply", "hsuforum");
-} else {
-    if ($forum->type == 'qanda') {
-        $formheading = get_string('yournewquestion', 'hsuforum');
-    } else {
-        $formheading = get_string('yournewtopic', 'hsuforum');
-        // Hide duplicated hsuforum description when creating a new discussion topic, see INT-18928.
-        $hidehtml = '';
-        $hidehtml .= html_writer::start_tag('style', array('type' => 'text/css')) . "\n";
-        $hidehtml .= '
-        #page-mod-hsuforum-post .activity-description,
-        #page-mod-hsuforum-post [role="main"] h2 {
-            display: none;
-        };';
-        $hidehtml .= html_writer::end_tag('style') . "\n";
-        echo $hidehtml;
-    }
-}
-
 if (hsuforum_is_subscribed($USER->id, $forum->id) || $USER->autosubscribe) {
     $subscribe = true;
 } else if (hsuforum_user_has_posted($forum->id, 0, $USER->id)) {
@@ -1049,6 +1028,27 @@ if (!empty($parent)) {
 if (!empty($CFG->enableplagiarism)) {
     require_once($CFG->libdir.'/plagiarismlib.php');
     echo plagiarism_print_disclosure($cm->id);
+}
+
+$formheading = '';
+if (!empty($parent)) {
+    $formheading = get_string("yourreply", "hsuforum");
+} else {
+    if ($forum->type == 'qanda') {
+        $formheading = get_string('yournewquestion', 'hsuforum');
+    } else {
+        $formheading = get_string('yournewtopic', 'hsuforum');
+        // Hide duplicated hsuforum description when creating a new discussion topic, see INT-18928.
+        $hidehtml = '';
+        $hidehtml .= html_writer::start_tag('style', array('type' => 'text/css')) . "\n";
+        $hidehtml .= '
+        #page-mod-hsuforum-post .activity-description,
+        #page-mod-hsuforum-post [role="main"] h2 {
+            display: none;
+        };';
+        $hidehtml .= html_writer::end_tag('style') . "\n";
+        echo $hidehtml;
+    }
 }
 
 if (!empty($formheading)) {


### PR DESCRIPTION
This fixes an issue where editor_tiny doesn't load on the post.php page because there is output (in this case, a style tag) above the <!DOCTYPE html> tag, which forces the page into quirks mode. TinyMCE doesn't load in quirks mode: https://stackoverflow.com/questions/68689918/tinymce-editor-is-not-loading-because-document-is-not-in-standards-mode-how-ca